### PR TITLE
fix typo (Github -> GitHub)

### DIFF
--- a/examples/sourcegraph-sourcegraph/cmd/frontend/internal/httpapi/webhookhandlers.md
+++ b/examples/sourcegraph-sourcegraph/cmd/frontend/internal/httpapi/webhookhandlers.md
@@ -87,7 +87,7 @@ tags: [function private]
 func handleGitHubRepoAuthzEvent(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error
 ```
 
-handleGithubRepoAuthzEvent handles any github event containing a repository field, and enqueues the contained repo for permissions synchronisation. 
+handleGitHubRepoAuthzEvent handles any github event containing a repository field, and enqueues the contained repo for permissions synchronisation. 
 
 ### <a id="handleGitHubUserAuthzEvent" href="#handleGitHubUserAuthzEvent">func handleGitHubUserAuthzEvent(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error</a>
 

--- a/examples/sourcegraph-sourcegraph/cmd/frontend/webhooks.md
+++ b/examples/sourcegraph-sourcegraph/cmd/frontend/webhooks.md
@@ -15,11 +15,11 @@
     * [type Registerer interface](#Registerer)
     * [type WebhookHandler func(ctx context.Context, extSvc *github.com/sourcegraph/sourcegraph/internal/types.ExternalService, event interface{}) error](#WebhookHandler)
 * [Functions](#func)
-    * [func TestGithubWebhookDispatchError(t *testing.T)](#TestGithubWebhookDispatchError)
-    * [func TestGithubWebhookDispatchNoHandler(t *testing.T)](#TestGithubWebhookDispatchNoHandler)
-    * [func TestGithubWebhookDispatchSuccess(t *testing.T)](#TestGithubWebhookDispatchSuccess)
-    * [func TestGithubWebhookDispatchSuccessMultiple(t *testing.T)](#TestGithubWebhookDispatchSuccessMultiple)
-    * [func TestGithubWebhookExternalServices(t *testing.T)](#TestGithubWebhookExternalServices)
+    * [func TestGitHubWebhookDispatchError(t *testing.T)](#TestGitHubWebhookDispatchError)
+    * [func TestGitHubWebhookDispatchNoHandler(t *testing.T)](#TestGitHubWebhookDispatchNoHandler)
+    * [func TestGitHubWebhookDispatchSuccess(t *testing.T)](#TestGitHubWebhookDispatchSuccess)
+    * [func TestGitHubWebhookDispatchSuccessMultiple(t *testing.T)](#TestGitHubWebhookDispatchSuccessMultiple)
+    * [func TestGitHubWebhookExternalServices(t *testing.T)](#TestGitHubWebhookExternalServices)
     * [func errString(err error) string](#errString)
     * [func marshalJSON(t testing.TB, v interface{}) string](#marshalJSON)
     * [func sign(t *testing.T, message, secret []byte) string](#sign)
@@ -67,7 +67,7 @@ type GitHubWebhook struct {
 }
 ```
 
-GitHubWebhook is responsible for handling incoming http requests for github webhooks and routing to any registered WebhookHandlers, events are routed by their event type, passed in the X-Github-Event header 
+GitHubWebhook is responsible for handling incoming http requests for github webhooks and routing to any registered WebhookHandlers, events are routed by their event type, passed in the X-GitHub-Event header 
 
 #### <a id="GitHubWebhook.Dispatch" href="#GitHubWebhook.Dispatch">func (h *GitHubWebhook) Dispatch(ctx context.Context, eventType string, extSvc *types.ExternalService, e interface{}) error</a>
 
@@ -158,59 +158,59 @@ WebhookHandler is a handler for a webhook event, the 'event' param could be any 
 
 ## <a id="func" href="#func">Functions</a>
 
-### <a id="TestGithubWebhookDispatchError" href="#TestGithubWebhookDispatchError">func TestGithubWebhookDispatchError(t *testing.T)</a>
+### <a id="TestGitHubWebhookDispatchError" href="#TestGitHubWebhookDispatchError">func TestGitHubWebhookDispatchError(t *testing.T)</a>
 
 ```
-searchKey: webhooks.TestGithubWebhookDispatchError
+searchKey: webhooks.TestGitHubWebhookDispatchError
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubWebhookDispatchError(t *testing.T)
+func TestGitHubWebhookDispatchError(t *testing.T)
 ```
 
-### <a id="TestGithubWebhookDispatchNoHandler" href="#TestGithubWebhookDispatchNoHandler">func TestGithubWebhookDispatchNoHandler(t *testing.T)</a>
+### <a id="TestGitHubWebhookDispatchNoHandler" href="#TestGitHubWebhookDispatchNoHandler">func TestGitHubWebhookDispatchNoHandler(t *testing.T)</a>
 
 ```
-searchKey: webhooks.TestGithubWebhookDispatchNoHandler
+searchKey: webhooks.TestGitHubWebhookDispatchNoHandler
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubWebhookDispatchNoHandler(t *testing.T)
+func TestGitHubWebhookDispatchNoHandler(t *testing.T)
 ```
 
-### <a id="TestGithubWebhookDispatchSuccess" href="#TestGithubWebhookDispatchSuccess">func TestGithubWebhookDispatchSuccess(t *testing.T)</a>
+### <a id="TestGitHubWebhookDispatchSuccess" href="#TestGitHubWebhookDispatchSuccess">func TestGitHubWebhookDispatchSuccess(t *testing.T)</a>
 
 ```
-searchKey: webhooks.TestGithubWebhookDispatchSuccess
+searchKey: webhooks.TestGitHubWebhookDispatchSuccess
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubWebhookDispatchSuccess(t *testing.T)
+func TestGitHubWebhookDispatchSuccess(t *testing.T)
 ```
 
-### <a id="TestGithubWebhookDispatchSuccessMultiple" href="#TestGithubWebhookDispatchSuccessMultiple">func TestGithubWebhookDispatchSuccessMultiple(t *testing.T)</a>
+### <a id="TestGitHubWebhookDispatchSuccessMultiple" href="#TestGitHubWebhookDispatchSuccessMultiple">func TestGitHubWebhookDispatchSuccessMultiple(t *testing.T)</a>
 
 ```
-searchKey: webhooks.TestGithubWebhookDispatchSuccessMultiple
+searchKey: webhooks.TestGitHubWebhookDispatchSuccessMultiple
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubWebhookDispatchSuccessMultiple(t *testing.T)
+func TestGitHubWebhookDispatchSuccessMultiple(t *testing.T)
 ```
 
-### <a id="TestGithubWebhookExternalServices" href="#TestGithubWebhookExternalServices">func TestGithubWebhookExternalServices(t *testing.T)</a>
+### <a id="TestGitHubWebhookExternalServices" href="#TestGitHubWebhookExternalServices">func TestGitHubWebhookExternalServices(t *testing.T)</a>
 
 ```
-searchKey: webhooks.TestGithubWebhookExternalServices
+searchKey: webhooks.TestGitHubWebhookExternalServices
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubWebhookExternalServices(t *testing.T)
+func TestGitHubWebhookExternalServices(t *testing.T)
 ```
 
 ### <a id="errString" href="#errString">func errString(err error) string</a>

--- a/examples/sourcegraph-sourcegraph/cmd/repo-updater/repoupdater.md
+++ b/examples/sourcegraph-sourcegraph/cmd/repo-updater/repoupdater.md
@@ -136,7 +136,7 @@ type Server struct {
 	*repos.Store
 	*repos.Syncer
 	SourcegraphDotComMode bool
-	GithubDotComSource    interface {
+	GitHubDotComSource    interface {
 		GetRepo(ctx context.Context, nameWithOwner string) (*types.Repo, error)
 	}
 	GitLabDotComSource interface {

--- a/examples/sourcegraph-sourcegraph/enterprise/cmd/frontend/internal/codeintel/httpapi.md
+++ b/examples/sourcegraph-sourcegraph/enterprise/cmd/frontend/internal/codeintel/httpapi.md
@@ -122,7 +122,7 @@
     * [func clientError(message string, vals ...interface{}) error](#clientError)
     * [func copyAll(w http.ResponseWriter, r io.Reader)](#copyAll)
     * [func enforceAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, repoName string) bool](#enforceAuth)
-    * [func enforceAuthGithub(ctx context.Context, w http.ResponseWriter, r *http.Request, repoName string) (int, error)](#enforceAuthGithub)
+    * [func enforceAuthGitHub(ctx context.Context, w http.ResponseWriter, r *http.Request, repoName string) (int, error)](#enforceAuthGitHub)
     * [func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoName, commit string) (*types.Repo, bool)](#ensureRepoAndCommitExist)
     * [func formatAWSError(err error) string](#formatAWSError)
     * [func getQuery(r *http.Request, name string) string](#getQuery)
@@ -1789,15 +1789,15 @@ tags: [function private]
 func enforceAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, repoName string) bool
 ```
 
-### <a id="enforceAuthGithub" href="#enforceAuthGithub">func enforceAuthGithub(ctx context.Context, w http.ResponseWriter, r *http.Request, repoName string) (int, error)</a>
+### <a id="enforceAuthGitHub" href="#enforceAuthGitHub">func enforceAuthGitHub(ctx context.Context, w http.ResponseWriter, r *http.Request, repoName string) (int, error)</a>
 
 ```
-searchKey: httpapi.enforceAuthGithub
+searchKey: httpapi.enforceAuthGitHub
 tags: [function private]
 ```
 
 ```Go
-func enforceAuthGithub(ctx context.Context, w http.ResponseWriter, r *http.Request, repoName string) (int, error)
+func enforceAuthGitHub(ctx context.Context, w http.ResponseWriter, r *http.Request, repoName string) (int, error)
 ```
 
 ### <a id="ensureRepoAndCommitExist" href="#ensureRepoAndCommitExist">func ensureRepoAndCommitExist(ctx context.Context, w http.ResponseWriter, repoName, commit string) (*types.Repo, bool)</a>

--- a/examples/sourcegraph-sourcegraph/enterprise/internal/batches/reconciler.md
+++ b/examples/sourcegraph-sourcegraph/enterprise/internal/batches/reconciler.md
@@ -74,7 +74,7 @@
     * [func TestReconcilerProcess_IntegrationTest(t *testing.T)](#TestReconcilerProcess_IntegrationTest)
     * [func batchChangeURL(ctx context.Context, ns *database.Namespace, c *btypes.BatchChange) (string, error)](#batchChangeURL)
     * [func buildCommitOpts(repo *types.Repo, spec *btypes.ChangesetSpec, pushOpts *protocol.PushConfig) (opts protocol.CreateCommitFromPatchRequest, err error)](#buildCommitOpts)
-    * [func buildGithubPR(now time.Time, externalState btypes.ChangesetExternalState) *github.PullRequest](#buildGithubPR)
+    * [func buildGitHubPR(now time.Time, externalState btypes.ChangesetExternalState) *github.PullRequest](#buildGitHubPR)
     * [func decorateChangesetBody(ctx context.Context, tx getBatchChanger, nsStore getNamespacer, cs *sources.Changeset) error](#decorateChangesetBody)
     * [func executePlan(ctx context.Context, gitserverClient GitserverClient, sourcer sources.Sourcer, noSleepBeforeSync bool, tx *store.Store, plan *Plan) (err error)](#executePlan)
     * [func loadBatchChange(ctx context.Context, tx getBatchChanger, id int64) (*btypes.BatchChange, error)](#loadBatchChange)
@@ -959,15 +959,15 @@ tags: [function private]
 func buildCommitOpts(repo *types.Repo, spec *btypes.ChangesetSpec, pushOpts *protocol.PushConfig) (opts protocol.CreateCommitFromPatchRequest, err error)
 ```
 
-### <a id="buildGithubPR" href="#buildGithubPR">func buildGithubPR(now time.Time, externalState btypes.ChangesetExternalState) *github.PullRequest</a>
+### <a id="buildGitHubPR" href="#buildGitHubPR">func buildGitHubPR(now time.Time, externalState btypes.ChangesetExternalState) *github.PullRequest</a>
 
 ```
-searchKey: reconciler.buildGithubPR
+searchKey: reconciler.buildGitHubPR
 tags: [function private]
 ```
 
 ```Go
-func buildGithubPR(now time.Time, externalState btypes.ChangesetExternalState) *github.PullRequest
+func buildGitHubPR(now time.Time, externalState btypes.ChangesetExternalState) *github.PullRequest
 ```
 
 ### <a id="decorateChangesetBody" href="#decorateChangesetBody">func decorateChangesetBody(ctx context.Context, tx getBatchChanger, nsStore getNamespacer, cs *sources.Changeset) error</a>

--- a/examples/sourcegraph-sourcegraph/enterprise/internal/batches/sources.md
+++ b/examples/sourcegraph-sourcegraph/enterprise/internal/batches/sources.md
@@ -75,22 +75,22 @@
         * [func (s *GitLabSource) getMergeRequestNotes(ctx context.Context, project *gitlab.Project, mr *gitlab.MergeRequest) ([]*gitlab.Note, error)](#GitLabSource.getMergeRequestNotes)
         * [func (s *GitLabSource) getMergeRequestPipelines(ctx context.Context, project *gitlab.Project, mr *gitlab.MergeRequest) ([]*gitlab.Pipeline, error)](#GitLabSource.getMergeRequestPipelines)
         * [func (s *GitLabSource) getMergeRequestResourceStateEvents(ctx context.Context, project *gitlab.Project, mr *gitlab.MergeRequest) ([]*gitlab.ResourceStateEvent, error)](#GitLabSource.getMergeRequestResourceStateEvents)
-    * [type GithubSource struct](#GithubSource)
-        * [func NewGithubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GithubSource, error)](#NewGithubSource)
-        * [func newGithubSource(c *schema.GitHubConnection, cf *httpcli.Factory, au auth.Authenticator) (*GithubSource, error)](#newGithubSource)
-        * [func (s GithubSource) CloseChangeset(ctx context.Context, c *Changeset) error](#GithubSource.CloseChangeset)
-        * [func (s GithubSource) CreateChangeset(ctx context.Context, c *Changeset) (bool, error)](#GithubSource.CreateChangeset)
-        * [func (s GithubSource) CreateComment(ctx context.Context, c *Changeset, text string) error](#GithubSource.CreateComment)
-        * [func (s GithubSource) CreateDraftChangeset(ctx context.Context, c *Changeset) (bool, error)](#GithubSource.CreateDraftChangeset)
-        * [func (s GithubSource) GitserverPushConfig(ctx context.Context, store *database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error)](#GithubSource.GitserverPushConfig)
-        * [func (s GithubSource) LoadChangeset(ctx context.Context, cs *Changeset) error](#GithubSource.LoadChangeset)
-        * [func (s GithubSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error](#GithubSource.MergeChangeset)
-        * [func (s GithubSource) ReopenChangeset(ctx context.Context, c *Changeset) error](#GithubSource.ReopenChangeset)
-        * [func (s GithubSource) UndraftChangeset(ctx context.Context, c *Changeset) error](#GithubSource.UndraftChangeset)
-        * [func (s GithubSource) UpdateChangeset(ctx context.Context, c *Changeset) error](#GithubSource.UpdateChangeset)
-        * [func (s GithubSource) ValidateAuthenticator(ctx context.Context) error](#GithubSource.ValidateAuthenticator)
-        * [func (s GithubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error)](#GithubSource.WithAuthenticator)
-        * [func (s GithubSource) createChangeset(ctx context.Context, c *Changeset, prInput *github.CreatePullRequestInput) (bool, error)](#GithubSource.createChangeset)
+    * [type GitHubSource struct](#GitHubSource)
+        * [func NewGitHubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GitHubSource, error)](#NewGitHubSource)
+        * [func newGitHubSource(c *schema.GitHubConnection, cf *httpcli.Factory, au auth.Authenticator) (*GitHubSource, error)](#newGitHubSource)
+        * [func (s GitHubSource) CloseChangeset(ctx context.Context, c *Changeset) error](#GitHubSource.CloseChangeset)
+        * [func (s GitHubSource) CreateChangeset(ctx context.Context, c *Changeset) (bool, error)](#GitHubSource.CreateChangeset)
+        * [func (s GitHubSource) CreateComment(ctx context.Context, c *Changeset, text string) error](#GitHubSource.CreateComment)
+        * [func (s GitHubSource) CreateDraftChangeset(ctx context.Context, c *Changeset) (bool, error)](#GitHubSource.CreateDraftChangeset)
+        * [func (s GitHubSource) GitserverPushConfig(ctx context.Context, store *database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error)](#GitHubSource.GitserverPushConfig)
+        * [func (s GitHubSource) LoadChangeset(ctx context.Context, cs *Changeset) error](#GitHubSource.LoadChangeset)
+        * [func (s GitHubSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error](#GitHubSource.MergeChangeset)
+        * [func (s GitHubSource) ReopenChangeset(ctx context.Context, c *Changeset) error](#GitHubSource.ReopenChangeset)
+        * [func (s GitHubSource) UndraftChangeset(ctx context.Context, c *Changeset) error](#GitHubSource.UndraftChangeset)
+        * [func (s GitHubSource) UpdateChangeset(ctx context.Context, c *Changeset) error](#GitHubSource.UpdateChangeset)
+        * [func (s GitHubSource) ValidateAuthenticator(ctx context.Context) error](#GitHubSource.ValidateAuthenticator)
+        * [func (s GitHubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error)](#GitHubSource.WithAuthenticator)
+        * [func (s GitHubSource) createChangeset(ctx context.Context, c *Changeset, prInput *github.CreatePullRequestInput) (bool, error)](#GitHubSource.createChangeset)
     * [type Sourcer interface](#Sourcer)
         * [func NewFakeSourcer(err error, source ChangesetSource) Sourcer](#NewFakeSourcer)
         * [func NewSourcer(cf *httpcli.Factory) Sourcer](#NewSourcer)
@@ -132,13 +132,13 @@
     * [func TestExtractCloneURL(t *testing.T)](#TestExtractCloneURL)
     * [func TestGitLabSource_ChangesetSource(t *testing.T)](#TestGitLabSource_ChangesetSource)
     * [func TestGitLabSource_WithAuthenticator(t *testing.T)](#TestGitLabSource_WithAuthenticator)
-    * [func TestGithubSource_CloseChangeset(t *testing.T)](#TestGithubSource_CloseChangeset)
-    * [func TestGithubSource_CreateChangeset(t *testing.T)](#TestGithubSource_CreateChangeset)
-    * [func TestGithubSource_CreateComment(t *testing.T)](#TestGithubSource_CreateComment)
-    * [func TestGithubSource_LoadChangeset(t *testing.T)](#TestGithubSource_LoadChangeset)
-    * [func TestGithubSource_ReopenChangeset(t *testing.T)](#TestGithubSource_ReopenChangeset)
-    * [func TestGithubSource_UpdateChangeset(t *testing.T)](#TestGithubSource_UpdateChangeset)
-    * [func TestGithubSource_WithAuthenticator(t *testing.T)](#TestGithubSource_WithAuthenticator)
+    * [func TestGitHubSource_CloseChangeset(t *testing.T)](#TestGitHubSource_CloseChangeset)
+    * [func TestGitHubSource_CreateChangeset(t *testing.T)](#TestGitHubSource_CreateChangeset)
+    * [func TestGitHubSource_CreateComment(t *testing.T)](#TestGitHubSource_CreateComment)
+    * [func TestGitHubSource_LoadChangeset(t *testing.T)](#TestGitHubSource_LoadChangeset)
+    * [func TestGitHubSource_ReopenChangeset(t *testing.T)](#TestGitHubSource_ReopenChangeset)
+    * [func TestGitHubSource_UpdateChangeset(t *testing.T)](#TestGitHubSource_UpdateChangeset)
+    * [func TestGitHubSource_WithAuthenticator(t *testing.T)](#TestGitHubSource_WithAuthenticator)
     * [func TestGitserverPushConfig(t *testing.T)](#TestGitserverPushConfig)
     * [func TestLoadExternalService(t *testing.T)](#TestLoadExternalService)
     * [func TestMain(m *testing.M)](#TestMain)
@@ -1150,201 +1150,201 @@ func (s *GitLabSource) getMergeRequestResourceStateEvents(ctx context.Context, p
 
 getMergeRequestResourceStateEvents retrieves the events attached to a merge request in descending time order. 
 
-### <a id="GithubSource" href="#GithubSource">type GithubSource struct</a>
+### <a id="GitHubSource" href="#GitHubSource">type GitHubSource struct</a>
 
 ```
-searchKey: sources.GithubSource
+searchKey: sources.GitHubSource
 tags: [struct]
 ```
 
 ```Go
-type GithubSource struct {
+type GitHubSource struct {
 	client *github.V4Client
 	au     auth.Authenticator
 }
 ```
 
-#### <a id="NewGithubSource" href="#NewGithubSource">func NewGithubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GithubSource, error)</a>
+#### <a id="NewGitHubSource" href="#NewGitHubSource">func NewGitHubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GitHubSource, error)</a>
 
 ```
-searchKey: sources.NewGithubSource
+searchKey: sources.NewGitHubSource
 tags: [function]
 ```
 
 ```Go
-func NewGithubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GithubSource, error)
+func NewGitHubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GitHubSource, error)
 ```
 
-#### <a id="newGithubSource" href="#newGithubSource">func newGithubSource(c *schema.GitHubConnection, cf *httpcli.Factory, au auth.Authenticator) (*GithubSource, error)</a>
+#### <a id="newGitHubSource" href="#newGitHubSource">func newGitHubSource(c *schema.GitHubConnection, cf *httpcli.Factory, au auth.Authenticator) (*GitHubSource, error)</a>
 
 ```
-searchKey: sources.newGithubSource
+searchKey: sources.newGitHubSource
 tags: [function private]
 ```
 
 ```Go
-func newGithubSource(c *schema.GitHubConnection, cf *httpcli.Factory, au auth.Authenticator) (*GithubSource, error)
+func newGitHubSource(c *schema.GitHubConnection, cf *httpcli.Factory, au auth.Authenticator) (*GitHubSource, error)
 ```
 
-#### <a id="GithubSource.CloseChangeset" href="#GithubSource.CloseChangeset">func (s GithubSource) CloseChangeset(ctx context.Context, c *Changeset) error</a>
+#### <a id="GitHubSource.CloseChangeset" href="#GitHubSource.CloseChangeset">func (s GitHubSource) CloseChangeset(ctx context.Context, c *Changeset) error</a>
 
 ```
-searchKey: sources.GithubSource.CloseChangeset
+searchKey: sources.GitHubSource.CloseChangeset
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) CloseChangeset(ctx context.Context, c *Changeset) error
+func (s GitHubSource) CloseChangeset(ctx context.Context, c *Changeset) error
 ```
 
 CloseChangeset closes the given *Changeset on the code host and updates the Metadata column in the *batches.Changeset to the newly closed pull request. 
 
-#### <a id="GithubSource.CreateChangeset" href="#GithubSource.CreateChangeset">func (s GithubSource) CreateChangeset(ctx context.Context, c *Changeset) (bool, error)</a>
+#### <a id="GitHubSource.CreateChangeset" href="#GitHubSource.CreateChangeset">func (s GitHubSource) CreateChangeset(ctx context.Context, c *Changeset) (bool, error)</a>
 
 ```
-searchKey: sources.GithubSource.CreateChangeset
+searchKey: sources.GitHubSource.CreateChangeset
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) CreateChangeset(ctx context.Context, c *Changeset) (bool, error)
+func (s GitHubSource) CreateChangeset(ctx context.Context, c *Changeset) (bool, error)
 ```
 
 CreateChangeset creates the given changeset on the code host. 
 
-#### <a id="GithubSource.CreateComment" href="#GithubSource.CreateComment">func (s GithubSource) CreateComment(ctx context.Context, c *Changeset, text string) error</a>
+#### <a id="GitHubSource.CreateComment" href="#GitHubSource.CreateComment">func (s GitHubSource) CreateComment(ctx context.Context, c *Changeset, text string) error</a>
 
 ```
-searchKey: sources.GithubSource.CreateComment
+searchKey: sources.GitHubSource.CreateComment
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) CreateComment(ctx context.Context, c *Changeset, text string) error
+func (s GitHubSource) CreateComment(ctx context.Context, c *Changeset, text string) error
 ```
 
 CreateComment posts a comment on the Changeset. 
 
-#### <a id="GithubSource.CreateDraftChangeset" href="#GithubSource.CreateDraftChangeset">func (s GithubSource) CreateDraftChangeset(ctx context.Context, c *Changeset) (bool, error)</a>
+#### <a id="GitHubSource.CreateDraftChangeset" href="#GitHubSource.CreateDraftChangeset">func (s GitHubSource) CreateDraftChangeset(ctx context.Context, c *Changeset) (bool, error)</a>
 
 ```
-searchKey: sources.GithubSource.CreateDraftChangeset
+searchKey: sources.GitHubSource.CreateDraftChangeset
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) CreateDraftChangeset(ctx context.Context, c *Changeset) (bool, error)
+func (s GitHubSource) CreateDraftChangeset(ctx context.Context, c *Changeset) (bool, error)
 ```
 
 CreateDraftChangeset creates the given changeset on the code host in draft mode. 
 
-#### <a id="GithubSource.GitserverPushConfig" href="#GithubSource.GitserverPushConfig">func (s GithubSource) GitserverPushConfig(ctx context.Context, store *database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error)</a>
+#### <a id="GitHubSource.GitserverPushConfig" href="#GitHubSource.GitserverPushConfig">func (s GitHubSource) GitserverPushConfig(ctx context.Context, store *database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error)</a>
 
 ```
-searchKey: sources.GithubSource.GitserverPushConfig
+searchKey: sources.GitHubSource.GitserverPushConfig
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) GitserverPushConfig(ctx context.Context, store *database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error)
+func (s GitHubSource) GitserverPushConfig(ctx context.Context, store *database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error)
 ```
 
-#### <a id="GithubSource.LoadChangeset" href="#GithubSource.LoadChangeset">func (s GithubSource) LoadChangeset(ctx context.Context, cs *Changeset) error</a>
+#### <a id="GitHubSource.LoadChangeset" href="#GitHubSource.LoadChangeset">func (s GitHubSource) LoadChangeset(ctx context.Context, cs *Changeset) error</a>
 
 ```
-searchKey: sources.GithubSource.LoadChangeset
+searchKey: sources.GitHubSource.LoadChangeset
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) LoadChangeset(ctx context.Context, cs *Changeset) error
+func (s GitHubSource) LoadChangeset(ctx context.Context, cs *Changeset) error
 ```
 
 LoadChangeset loads the latest state of the given Changeset from the codehost. 
 
-#### <a id="GithubSource.MergeChangeset" href="#GithubSource.MergeChangeset">func (s GithubSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error</a>
+#### <a id="GitHubSource.MergeChangeset" href="#GitHubSource.MergeChangeset">func (s GitHubSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error</a>
 
 ```
-searchKey: sources.GithubSource.MergeChangeset
+searchKey: sources.GitHubSource.MergeChangeset
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error
+func (s GitHubSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error
 ```
 
 MergeChangeset merges a Changeset on the code host, if in a mergeable state. If squash is true, a squash-then-merge merge will be performed. 
 
-#### <a id="GithubSource.ReopenChangeset" href="#GithubSource.ReopenChangeset">func (s GithubSource) ReopenChangeset(ctx context.Context, c *Changeset) error</a>
+#### <a id="GitHubSource.ReopenChangeset" href="#GitHubSource.ReopenChangeset">func (s GitHubSource) ReopenChangeset(ctx context.Context, c *Changeset) error</a>
 
 ```
-searchKey: sources.GithubSource.ReopenChangeset
+searchKey: sources.GitHubSource.ReopenChangeset
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) ReopenChangeset(ctx context.Context, c *Changeset) error
+func (s GitHubSource) ReopenChangeset(ctx context.Context, c *Changeset) error
 ```
 
 ReopenChangeset reopens the given *Changeset on the code host. 
 
-#### <a id="GithubSource.UndraftChangeset" href="#GithubSource.UndraftChangeset">func (s GithubSource) UndraftChangeset(ctx context.Context, c *Changeset) error</a>
+#### <a id="GitHubSource.UndraftChangeset" href="#GitHubSource.UndraftChangeset">func (s GitHubSource) UndraftChangeset(ctx context.Context, c *Changeset) error</a>
 
 ```
-searchKey: sources.GithubSource.UndraftChangeset
+searchKey: sources.GitHubSource.UndraftChangeset
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) UndraftChangeset(ctx context.Context, c *Changeset) error
+func (s GitHubSource) UndraftChangeset(ctx context.Context, c *Changeset) error
 ```
 
 UndraftChangeset will update the Changeset on the source to be not in draft mode anymore. 
 
-#### <a id="GithubSource.UpdateChangeset" href="#GithubSource.UpdateChangeset">func (s GithubSource) UpdateChangeset(ctx context.Context, c *Changeset) error</a>
+#### <a id="GitHubSource.UpdateChangeset" href="#GitHubSource.UpdateChangeset">func (s GitHubSource) UpdateChangeset(ctx context.Context, c *Changeset) error</a>
 
 ```
-searchKey: sources.GithubSource.UpdateChangeset
+searchKey: sources.GitHubSource.UpdateChangeset
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) UpdateChangeset(ctx context.Context, c *Changeset) error
+func (s GitHubSource) UpdateChangeset(ctx context.Context, c *Changeset) error
 ```
 
 UpdateChangeset updates the given *Changeset in the code host. 
 
-#### <a id="GithubSource.ValidateAuthenticator" href="#GithubSource.ValidateAuthenticator">func (s GithubSource) ValidateAuthenticator(ctx context.Context) error</a>
+#### <a id="GitHubSource.ValidateAuthenticator" href="#GitHubSource.ValidateAuthenticator">func (s GitHubSource) ValidateAuthenticator(ctx context.Context) error</a>
 
 ```
-searchKey: sources.GithubSource.ValidateAuthenticator
+searchKey: sources.GitHubSource.ValidateAuthenticator
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) ValidateAuthenticator(ctx context.Context) error
+func (s GitHubSource) ValidateAuthenticator(ctx context.Context) error
 ```
 
-#### <a id="GithubSource.WithAuthenticator" href="#GithubSource.WithAuthenticator">func (s GithubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error)</a>
+#### <a id="GitHubSource.WithAuthenticator" href="#GitHubSource.WithAuthenticator">func (s GitHubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error)</a>
 
 ```
-searchKey: sources.GithubSource.WithAuthenticator
+searchKey: sources.GitHubSource.WithAuthenticator
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error)
+func (s GitHubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error)
 ```
 
-#### <a id="GithubSource.createChangeset" href="#GithubSource.createChangeset">func (s GithubSource) createChangeset(ctx context.Context, c *Changeset, prInput *github.CreatePullRequestInput) (bool, error)</a>
+#### <a id="GitHubSource.createChangeset" href="#GitHubSource.createChangeset">func (s GitHubSource) createChangeset(ctx context.Context, c *Changeset, prInput *github.CreatePullRequestInput) (bool, error)</a>
 
 ```
-searchKey: sources.GithubSource.createChangeset
+searchKey: sources.GitHubSource.createChangeset
 tags: [method private]
 ```
 
 ```Go
-func (s GithubSource) createChangeset(ctx context.Context, c *Changeset, prInput *github.CreatePullRequestInput) (bool, error)
+func (s GitHubSource) createChangeset(ctx context.Context, c *Changeset, prInput *github.CreatePullRequestInput) (bool, error)
 ```
 
 ### <a id="Sourcer" href="#Sourcer">type Sourcer interface</a>
@@ -1840,81 +1840,81 @@ tags: [function private test]
 func TestGitLabSource_WithAuthenticator(t *testing.T)
 ```
 
-### <a id="TestGithubSource_CloseChangeset" href="#TestGithubSource_CloseChangeset">func TestGithubSource_CloseChangeset(t *testing.T)</a>
+### <a id="TestGitHubSource_CloseChangeset" href="#TestGitHubSource_CloseChangeset">func TestGitHubSource_CloseChangeset(t *testing.T)</a>
 
 ```
-searchKey: sources.TestGithubSource_CloseChangeset
+searchKey: sources.TestGitHubSource_CloseChangeset
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_CloseChangeset(t *testing.T)
+func TestGitHubSource_CloseChangeset(t *testing.T)
 ```
 
-### <a id="TestGithubSource_CreateChangeset" href="#TestGithubSource_CreateChangeset">func TestGithubSource_CreateChangeset(t *testing.T)</a>
+### <a id="TestGitHubSource_CreateChangeset" href="#TestGitHubSource_CreateChangeset">func TestGitHubSource_CreateChangeset(t *testing.T)</a>
 
 ```
-searchKey: sources.TestGithubSource_CreateChangeset
+searchKey: sources.TestGitHubSource_CreateChangeset
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_CreateChangeset(t *testing.T)
+func TestGitHubSource_CreateChangeset(t *testing.T)
 ```
 
-### <a id="TestGithubSource_CreateComment" href="#TestGithubSource_CreateComment">func TestGithubSource_CreateComment(t *testing.T)</a>
+### <a id="TestGitHubSource_CreateComment" href="#TestGitHubSource_CreateComment">func TestGitHubSource_CreateComment(t *testing.T)</a>
 
 ```
-searchKey: sources.TestGithubSource_CreateComment
+searchKey: sources.TestGitHubSource_CreateComment
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_CreateComment(t *testing.T)
+func TestGitHubSource_CreateComment(t *testing.T)
 ```
 
-### <a id="TestGithubSource_LoadChangeset" href="#TestGithubSource_LoadChangeset">func TestGithubSource_LoadChangeset(t *testing.T)</a>
+### <a id="TestGitHubSource_LoadChangeset" href="#TestGitHubSource_LoadChangeset">func TestGitHubSource_LoadChangeset(t *testing.T)</a>
 
 ```
-searchKey: sources.TestGithubSource_LoadChangeset
+searchKey: sources.TestGitHubSource_LoadChangeset
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_LoadChangeset(t *testing.T)
+func TestGitHubSource_LoadChangeset(t *testing.T)
 ```
 
-### <a id="TestGithubSource_ReopenChangeset" href="#TestGithubSource_ReopenChangeset">func TestGithubSource_ReopenChangeset(t *testing.T)</a>
+### <a id="TestGitHubSource_ReopenChangeset" href="#TestGitHubSource_ReopenChangeset">func TestGitHubSource_ReopenChangeset(t *testing.T)</a>
 
 ```
-searchKey: sources.TestGithubSource_ReopenChangeset
+searchKey: sources.TestGitHubSource_ReopenChangeset
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_ReopenChangeset(t *testing.T)
+func TestGitHubSource_ReopenChangeset(t *testing.T)
 ```
 
-### <a id="TestGithubSource_UpdateChangeset" href="#TestGithubSource_UpdateChangeset">func TestGithubSource_UpdateChangeset(t *testing.T)</a>
+### <a id="TestGitHubSource_UpdateChangeset" href="#TestGitHubSource_UpdateChangeset">func TestGitHubSource_UpdateChangeset(t *testing.T)</a>
 
 ```
-searchKey: sources.TestGithubSource_UpdateChangeset
+searchKey: sources.TestGitHubSource_UpdateChangeset
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_UpdateChangeset(t *testing.T)
+func TestGitHubSource_UpdateChangeset(t *testing.T)
 ```
 
-### <a id="TestGithubSource_WithAuthenticator" href="#TestGithubSource_WithAuthenticator">func TestGithubSource_WithAuthenticator(t *testing.T)</a>
+### <a id="TestGitHubSource_WithAuthenticator" href="#TestGitHubSource_WithAuthenticator">func TestGitHubSource_WithAuthenticator(t *testing.T)</a>
 
 ```
-searchKey: sources.TestGithubSource_WithAuthenticator
+searchKey: sources.TestGitHubSource_WithAuthenticator
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_WithAuthenticator(t *testing.T)
+func TestGitHubSource_WithAuthenticator(t *testing.T)
 ```
 
 ### <a id="TestGitserverPushConfig" href="#TestGitserverPushConfig">func TestGitserverPushConfig(t *testing.T)</a>

--- a/examples/sourcegraph-sourcegraph/enterprise/internal/batches/state.md
+++ b/examples/sourcegraph-sourcegraph/enterprise/internal/batches/state.md
@@ -27,7 +27,7 @@
     * [func TestComputeBitbucketBuildStatus(t *testing.T)](#TestComputeBitbucketBuildStatus)
     * [func TestComputeExternalState(t *testing.T)](#TestComputeExternalState)
     * [func TestComputeGitLabCheckState(t *testing.T)](#TestComputeGitLabCheckState)
-    * [func TestComputeGithubCheckState(t *testing.T)](#TestComputeGithubCheckState)
+    * [func TestComputeGitHubCheckState(t *testing.T)](#TestComputeGitHubCheckState)
     * [func TestComputeLabels(t *testing.T)](#TestComputeLabels)
     * [func TestComputeReviewState(t *testing.T)](#TestComputeReviewState)
     * [func bbsActivity(id int64, t time.Time, username string, kind btypes.ChangesetEventKind) *btypes.ChangesetEvent](#bbsActivity)
@@ -63,8 +63,8 @@
     * [func initialExternalState(ch *btypes.Changeset, ce ChangesetEvents) btypes.ChangesetExternalState](#initialExternalState)
     * [func parseBitbucketBuildState(s string) btypes.ChangesetCheckState](#parseBitbucketBuildState)
     * [func parseGitLabPipelineStatus(status gitlab.PipelineStatus) btypes.ChangesetCheckState](#parseGitLabPipelineStatus)
-    * [func parseGithubCheckState(s string) btypes.ChangesetCheckState](#parseGithubCheckState)
-    * [func parseGithubCheckSuiteState(status, conclusion string) btypes.ChangesetCheckState](#parseGithubCheckSuiteState)
+    * [func parseGitHubCheckState(s string) btypes.ChangesetCheckState](#parseGitHubCheckState)
+    * [func parseGitHubCheckSuiteState(status, conclusion string) btypes.ChangesetCheckState](#parseGitHubCheckSuiteState)
     * [func reduceReviewStates(statesByAuthor map[string]btypes.ChangesetReviewState) btypes.ChangesetReviewState](#reduceReviewStates)
     * [func selectReviewState(states map[btypes.ChangesetReviewState]bool) btypes.ChangesetReviewState](#selectReviewState)
     * [func setDeletedAt(c *btypes.Changeset, deletedAt time.Time) *btypes.Changeset](#setDeletedAt)
@@ -367,15 +367,15 @@ tags: [function private test]
 func TestComputeGitLabCheckState(t *testing.T)
 ```
 
-### <a id="TestComputeGithubCheckState" href="#TestComputeGithubCheckState">func TestComputeGithubCheckState(t *testing.T)</a>
+### <a id="TestComputeGitHubCheckState" href="#TestComputeGitHubCheckState">func TestComputeGitHubCheckState(t *testing.T)</a>
 
 ```
-searchKey: state.TestComputeGithubCheckState
+searchKey: state.TestComputeGitHubCheckState
 tags: [function private test]
 ```
 
 ```Go
-func TestComputeGithubCheckState(t *testing.T)
+func TestComputeGitHubCheckState(t *testing.T)
 ```
 
 ### <a id="TestComputeLabels" href="#TestComputeLabels">func TestComputeLabels(t *testing.T)</a>
@@ -785,26 +785,26 @@ tags: [function private]
 func parseGitLabPipelineStatus(status gitlab.PipelineStatus) btypes.ChangesetCheckState
 ```
 
-### <a id="parseGithubCheckState" href="#parseGithubCheckState">func parseGithubCheckState(s string) btypes.ChangesetCheckState</a>
+### <a id="parseGitHubCheckState" href="#parseGitHubCheckState">func parseGitHubCheckState(s string) btypes.ChangesetCheckState</a>
 
 ```
-searchKey: state.parseGithubCheckState
+searchKey: state.parseGitHubCheckState
 tags: [function private]
 ```
 
 ```Go
-func parseGithubCheckState(s string) btypes.ChangesetCheckState
+func parseGitHubCheckState(s string) btypes.ChangesetCheckState
 ```
 
-### <a id="parseGithubCheckSuiteState" href="#parseGithubCheckSuiteState">func parseGithubCheckSuiteState(status, conclusion string) btypes.ChangesetCheckState</a>
+### <a id="parseGitHubCheckSuiteState" href="#parseGitHubCheckSuiteState">func parseGitHubCheckSuiteState(status, conclusion string) btypes.ChangesetCheckState</a>
 
 ```
-searchKey: state.parseGithubCheckSuiteState
+searchKey: state.parseGitHubCheckSuiteState
 tags: [function private]
 ```
 
 ```Go
-func parseGithubCheckSuiteState(status, conclusion string) btypes.ChangesetCheckState
+func parseGitHubCheckSuiteState(status, conclusion string) btypes.ChangesetCheckState
 ```
 
 ### <a id="reduceReviewStates" href="#reduceReviewStates">func reduceReviewStates(statesByAuthor map[string]btypes.ChangesetReviewState) btypes.ChangesetReviewState</a>

--- a/examples/sourcegraph-sourcegraph/enterprise/internal/batches/webhooks.md
+++ b/examples/sourcegraph-sourcegraph/enterprise/internal/batches/webhooks.md
@@ -342,7 +342,7 @@ tags: [method private]
 func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error
 ```
 
-handleGithubWebhook is the entry point for webhooks from the webhook router, see the events it's registered to handle in GitHubWebhook.Register 
+handleGitHubWebhook is the entry point for webhooks from the webhook router, see the events it's registered to handle in GitHubWebhook.Register 
 
 #### <a id="GitHubWebhook.issueComment" href="#GitHubWebhook.issueComment">func (*GitHubWebhook) issueComment(e *gh.IssueCommentEvent) *github.IssueComment</a>
 

--- a/examples/sourcegraph-sourcegraph/internal/extsvc/github.md
+++ b/examples/sourcegraph-sourcegraph/internal/extsvc/github.md
@@ -1607,7 +1607,7 @@ type Team struct {
 }
 ```
 
-A Team represents a team on Github. 
+A Team represents a team on GitHub. 
 
 ### <a id="TimelineItem" href="#TimelineItem">type TimelineItem struct</a>
 
@@ -2248,7 +2248,7 @@ tags: [method]
 func (c *V4Client) ClosePullRequest(ctx context.Context, pr *PullRequest) error
 ```
 
-ClosePullRequest closes the PullRequest on Github. 
+ClosePullRequest closes the PullRequest on GitHub. 
 
 #### <a id="V4Client.CreatePullRequest" href="#V4Client.CreatePullRequest">func (c *V4Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestInput) (*PullRequest, error)</a>
 
@@ -2261,7 +2261,7 @@ tags: [method]
 func (c *V4Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestInput) (*PullRequest, error)
 ```
 
-CreatePullRequest creates a PullRequest on Github. 
+CreatePullRequest creates a PullRequest on GitHub. 
 
 #### <a id="V4Client.CreatePullRequestComment" href="#V4Client.CreatePullRequestComment">func (c *V4Client) CreatePullRequestComment(ctx context.Context, pr *PullRequest, body string) error</a>
 
@@ -2274,7 +2274,7 @@ tags: [method]
 func (c *V4Client) CreatePullRequestComment(ctx context.Context, pr *PullRequest, body string) error
 ```
 
-CreatePullRequestComment creates a comment on the PullRequest on Github. 
+CreatePullRequestComment creates a comment on the PullRequest on GitHub. 
 
 #### <a id="V4Client.GetAuthenticatedUser" href="#V4Client.GetAuthenticatedUser">func (c *V4Client) GetAuthenticatedUser(ctx context.Context) (*Actor, error)</a>
 
@@ -2328,7 +2328,7 @@ tags: [method]
 func (c *V4Client) LoadPullRequest(ctx context.Context, pr *PullRequest) error
 ```
 
-LoadPullRequest loads a PullRequest from Github. 
+LoadPullRequest loads a PullRequest from GitHub. 
 
 #### <a id="V4Client.MarkPullRequestReadyForReview" href="#V4Client.MarkPullRequestReadyForReview">func (c *V4Client) MarkPullRequestReadyForReview(ctx context.Context, pr *PullRequest) error</a>
 
@@ -2341,7 +2341,7 @@ tags: [method]
 func (c *V4Client) MarkPullRequestReadyForReview(ctx context.Context, pr *PullRequest) error
 ```
 
-MarkPullRequestReadyForReview marks the PullRequest on Github as ready for review. 
+MarkPullRequestReadyForReview marks the PullRequest on GitHub as ready for review. 
 
 #### <a id="V4Client.MergePullRequest" href="#V4Client.MergePullRequest">func (c *V4Client) MergePullRequest(ctx context.Context, pr *PullRequest, squash bool) error</a>
 
@@ -2354,7 +2354,7 @@ tags: [method]
 func (c *V4Client) MergePullRequest(ctx context.Context, pr *PullRequest, squash bool) error
 ```
 
-MergePullRequest tries to merge the PullRequest on Github. 
+MergePullRequest tries to merge the PullRequest on GitHub. 
 
 #### <a id="V4Client.RateLimitMonitor" href="#V4Client.RateLimitMonitor">func (c *V4Client) RateLimitMonitor() *ratelimit.Monitor</a>
 
@@ -2380,7 +2380,7 @@ tags: [method]
 func (c *V4Client) ReopenPullRequest(ctx context.Context, pr *PullRequest) error
 ```
 
-ReopenPullRequest reopens the PullRequest on Github. 
+ReopenPullRequest reopens the PullRequest on GitHub. 
 
 #### <a id="V4Client.UpdatePullRequest" href="#V4Client.UpdatePullRequest">func (c *V4Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInput) (*PullRequest, error)</a>
 
@@ -2393,7 +2393,7 @@ tags: [method]
 func (c *V4Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestInput) (*PullRequest, error)
 ```
 
-UpdatePullRequest creates a PullRequest on Github. 
+UpdatePullRequest creates a PullRequest on GitHub. 
 
 #### <a id="V4Client.WithAuthenticator" href="#V4Client.WithAuthenticator">func (c *V4Client) WithAuthenticator(a auth.Authenticator) *V4Client</a>
 

--- a/examples/sourcegraph-sourcegraph/internal/repos.md
+++ b/examples/sourcegraph-sourcegraph/internal/repos.md
@@ -121,29 +121,29 @@ Package repos providers workers to monitor code host APIs.
         * [func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceResult)](#GitLabSource.listAllProjects)
         * [func (s GitLabSource) makeRepo(proj *gitlab.Project) *types.Repo](#GitLabSource.makeRepo)
         * [func (s *GitLabSource) remoteURL(proj *gitlab.Project) string](#GitLabSource.remoteURL)
-    * [type GithubSource struct](#GithubSource)
-        * [func NewGithubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GithubSource, error)](#NewGithubSource)
-        * [func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf *httpcli.Factory) (*GithubSource, error)](#newGithubSource)
-        * [func (s *GithubSource) AffiliatedRepositories(ctx context.Context) ([]types.CodeHostRepository, error)](#GithubSource.AffiliatedRepositories)
-        * [func (s GithubSource) ExternalServices() types.ExternalServices](#GithubSource.ExternalServices)
-        * [func (s GithubSource) GetRepo(ctx context.Context, nameWithOwner string) (*types.Repo, error)](#GithubSource.GetRepo)
-        * [func (s GithubSource) ListRepos(ctx context.Context, results chan SourceResult)](#GithubSource.ListRepos)
-        * [func (s GithubSource) ValidateAuthenticator(ctx context.Context) error](#GithubSource.ValidateAuthenticator)
-        * [func (s GithubSource) WithAuthenticator(a auth.Authenticator) (Source, error)](#GithubSource.WithAuthenticator)
-        * [func (s *GithubSource) excludes(r *github.Repository) bool](#GithubSource.excludes)
-        * [func (s *GithubSource) fetchAllRepositoriesInBatches(ctx context.Context, results chan *githubResult) error](#GithubSource.fetchAllRepositoriesInBatches)
-        * [func (s *GithubSource) getRepository(ctx context.Context, nameWithOwner string) (*github.Repository, error)](#GithubSource.getRepository)
-        * [func (s *GithubSource) listAffiliated(ctx context.Context, results chan *githubResult)](#GithubSource.listAffiliated)
-        * [func (s *GithubSource) listAllRepositories(ctx context.Context, results chan *githubResult)](#GithubSource.listAllRepositories)
-        * [func (s *GithubSource) listOrg(ctx context.Context, org string, results chan *githubResult)](#GithubSource.listOrg)
-        * [func (s *GithubSource) listPublic(ctx context.Context, results chan *githubResult)](#GithubSource.listPublic)
-        * [func (s *GithubSource) listRepos(ctx context.Context, repos []string, results chan *githubResult)](#GithubSource.listRepos)
-        * [func (s *GithubSource) listRepositoryQuery(ctx context.Context, query string, results chan *githubResult)](#GithubSource.listRepositoryQuery)
-        * [func (s *GithubSource) listSearch(ctx context.Context, query string, results chan *githubResult)](#GithubSource.listSearch)
-        * [func (s *GithubSource) listUser(ctx context.Context, user string, results chan *githubResult) (fail error)](#GithubSource.listUser)
-        * [func (s GithubSource) makeRepo(r *github.Repository) *types.Repo](#GithubSource.makeRepo)
-        * [func (s *GithubSource) paginate(ctx context.Context, results chan *githubResult, pager repositoryPager)](#GithubSource.paginate)
-        * [func (s *GithubSource) remoteURL(repo *github.Repository) string](#GithubSource.remoteURL)
+    * [type GitHubSource struct](#GitHubSource)
+        * [func NewGitHubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GitHubSource, error)](#NewGitHubSource)
+        * [func newGitHubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf *httpcli.Factory) (*GitHubSource, error)](#newGitHubSource)
+        * [func (s *GitHubSource) AffiliatedRepositories(ctx context.Context) ([]types.CodeHostRepository, error)](#GitHubSource.AffiliatedRepositories)
+        * [func (s GitHubSource) ExternalServices() types.ExternalServices](#GitHubSource.ExternalServices)
+        * [func (s GitHubSource) GetRepo(ctx context.Context, nameWithOwner string) (*types.Repo, error)](#GitHubSource.GetRepo)
+        * [func (s GitHubSource) ListRepos(ctx context.Context, results chan SourceResult)](#GitHubSource.ListRepos)
+        * [func (s GitHubSource) ValidateAuthenticator(ctx context.Context) error](#GitHubSource.ValidateAuthenticator)
+        * [func (s GitHubSource) WithAuthenticator(a auth.Authenticator) (Source, error)](#GitHubSource.WithAuthenticator)
+        * [func (s *GitHubSource) excludes(r *github.Repository) bool](#GitHubSource.excludes)
+        * [func (s *GitHubSource) fetchAllRepositoriesInBatches(ctx context.Context, results chan *githubResult) error](#GitHubSource.fetchAllRepositoriesInBatches)
+        * [func (s *GitHubSource) getRepository(ctx context.Context, nameWithOwner string) (*github.Repository, error)](#GitHubSource.getRepository)
+        * [func (s *GitHubSource) listAffiliated(ctx context.Context, results chan *githubResult)](#GitHubSource.listAffiliated)
+        * [func (s *GitHubSource) listAllRepositories(ctx context.Context, results chan *githubResult)](#GitHubSource.listAllRepositories)
+        * [func (s *GitHubSource) listOrg(ctx context.Context, org string, results chan *githubResult)](#GitHubSource.listOrg)
+        * [func (s *GitHubSource) listPublic(ctx context.Context, results chan *githubResult)](#GitHubSource.listPublic)
+        * [func (s *GitHubSource) listRepos(ctx context.Context, repos []string, results chan *githubResult)](#GitHubSource.listRepos)
+        * [func (s *GitHubSource) listRepositoryQuery(ctx context.Context, query string, results chan *githubResult)](#GitHubSource.listRepositoryQuery)
+        * [func (s *GitHubSource) listSearch(ctx context.Context, query string, results chan *githubResult)](#GitHubSource.listSearch)
+        * [func (s *GitHubSource) listUser(ctx context.Context, user string, results chan *githubResult) (fail error)](#GitHubSource.listUser)
+        * [func (s GitHubSource) makeRepo(r *github.Repository) *types.Repo](#GitHubSource.makeRepo)
+        * [func (s *GitHubSource) paginate(ctx context.Context, results chan *githubResult, pager repositoryPager)](#GitHubSource.paginate)
+        * [func (s *GitHubSource) remoteURL(repo *github.Repository) string](#GitHubSource.remoteURL)
     * [type GitolitePhabricatorMetadataSyncer struct](#GitolitePhabricatorMetadataSyncer)
         * [func NewGitolitePhabricatorMetadataSyncer(s *Store) *GitolitePhabricatorMetadataSyncer](#NewGitolitePhabricatorMetadataSyncer)
         * [func (s *GitolitePhabricatorMetadataSyncer) Sync(ctx context.Context, repos []*types.Repo) error](#GitolitePhabricatorMetadataSyncer.Sync)
@@ -337,11 +337,11 @@ Package repos providers workers to monitor code host APIs.
     * [func TestGitLabSource_GetRepo(t *testing.T)](#TestGitLabSource_GetRepo)
     * [func TestGitLabSource_WithAuthenticator(t *testing.T)](#TestGitLabSource_WithAuthenticator)
     * [func TestGitLabSource_makeRepo(t *testing.T)](#TestGitLabSource_makeRepo)
-    * [func TestGithubSource_GetRepo(t *testing.T)](#TestGithubSource_GetRepo)
-    * [func TestGithubSource_ListRepos(t *testing.T)](#TestGithubSource_ListRepos)
-    * [func TestGithubSource_WithAuthenticator(t *testing.T)](#TestGithubSource_WithAuthenticator)
-    * [func TestGithubSource_excludes_disabledAndLocked(t *testing.T)](#TestGithubSource_excludes_disabledAndLocked)
-    * [func TestGithubSource_makeRepo(t *testing.T)](#TestGithubSource_makeRepo)
+    * [func TestGitHubSource_GetRepo(t *testing.T)](#TestGitHubSource_GetRepo)
+    * [func TestGitHubSource_ListRepos(t *testing.T)](#TestGitHubSource_ListRepos)
+    * [func TestGitHubSource_WithAuthenticator(t *testing.T)](#TestGitHubSource_WithAuthenticator)
+    * [func TestGitHubSource_excludes_disabledAndLocked(t *testing.T)](#TestGitHubSource_excludes_disabledAndLocked)
+    * [func TestGitHubSource_makeRepo(t *testing.T)](#TestGitHubSource_makeRepo)
     * [func TestGrantedScopes(t *testing.T)](#TestGrantedScopes)
     * [func TestHashToken(t *testing.T)](#TestHashToken)
     * [func TestIsSaturdayNight(t *testing.T)](#TestIsSaturdayNight)
@@ -1836,15 +1836,15 @@ remoteURL returns the GitLab projects's Git remote URL
 
 note: this used to contain credentials but that is no longer the case if you need to get an authenticated clone url use repos.CloneURL 
 
-### <a id="GithubSource" href="#GithubSource">type GithubSource struct</a>
+### <a id="GitHubSource" href="#GitHubSource">type GitHubSource struct</a>
 
 ```
-searchKey: repos.GithubSource
+searchKey: repos.GitHubSource
 tags: [struct]
 ```
 
 ```Go
-type GithubSource struct {
+type GitHubSource struct {
 	svc             *types.ExternalService
 	config          *schema.GitHubConnection
 	exclude         excludeFunc
@@ -1864,282 +1864,282 @@ type GithubSource struct {
 }
 ```
 
-A GithubSource yields repositories from a single Github connection configured in Sourcegraph via the external services configuration. 
+A GitHubSource yields repositories from a single GitHub connection configured in Sourcegraph via the external services configuration. 
 
-#### <a id="NewGithubSource" href="#NewGithubSource">func NewGithubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GithubSource, error)</a>
+#### <a id="NewGitHubSource" href="#NewGitHubSource">func NewGitHubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GitHubSource, error)</a>
 
 ```
-searchKey: repos.NewGithubSource
+searchKey: repos.NewGitHubSource
 tags: [function]
 ```
 
 ```Go
-func NewGithubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GithubSource, error)
+func NewGitHubSource(svc *types.ExternalService, cf *httpcli.Factory) (*GitHubSource, error)
 ```
 
-NewGithubSource returns a new GithubSource from the given external service. 
+NewGitHubSource returns a new GitHubSource from the given external service. 
 
-#### <a id="newGithubSource" href="#newGithubSource">func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf *httpcli.Factory) (*GithubSource, error)</a>
+#### <a id="newGitHubSource" href="#newGitHubSource">func newGitHubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf *httpcli.Factory) (*GitHubSource, error)</a>
 
 ```
-searchKey: repos.newGithubSource
+searchKey: repos.newGitHubSource
 tags: [function private]
 ```
 
 ```Go
-func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf *httpcli.Factory) (*GithubSource, error)
+func newGitHubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf *httpcli.Factory) (*GitHubSource, error)
 ```
 
-#### <a id="GithubSource.AffiliatedRepositories" href="#GithubSource.AffiliatedRepositories">func (s *GithubSource) AffiliatedRepositories(ctx context.Context) ([]types.CodeHostRepository, error)</a>
+#### <a id="GitHubSource.AffiliatedRepositories" href="#GitHubSource.AffiliatedRepositories">func (s *GitHubSource) AffiliatedRepositories(ctx context.Context) ([]types.CodeHostRepository, error)</a>
 
 ```
-searchKey: repos.GithubSource.AffiliatedRepositories
+searchKey: repos.GitHubSource.AffiliatedRepositories
 tags: [method]
 ```
 
 ```Go
-func (s *GithubSource) AffiliatedRepositories(ctx context.Context) ([]types.CodeHostRepository, error)
+func (s *GitHubSource) AffiliatedRepositories(ctx context.Context) ([]types.CodeHostRepository, error)
 ```
 
-#### <a id="GithubSource.ExternalServices" href="#GithubSource.ExternalServices">func (s GithubSource) ExternalServices() types.ExternalServices</a>
+#### <a id="GitHubSource.ExternalServices" href="#GitHubSource.ExternalServices">func (s GitHubSource) ExternalServices() types.ExternalServices</a>
 
 ```
-searchKey: repos.GithubSource.ExternalServices
+searchKey: repos.GitHubSource.ExternalServices
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) ExternalServices() types.ExternalServices
+func (s GitHubSource) ExternalServices() types.ExternalServices
 ```
 
 ExternalServices returns a singleton slice containing the external service. 
 
-#### <a id="GithubSource.GetRepo" href="#GithubSource.GetRepo">func (s GithubSource) GetRepo(ctx context.Context, nameWithOwner string) (*types.Repo, error)</a>
+#### <a id="GitHubSource.GetRepo" href="#GitHubSource.GetRepo">func (s GitHubSource) GetRepo(ctx context.Context, nameWithOwner string) (*types.Repo, error)</a>
 
 ```
-searchKey: repos.GithubSource.GetRepo
+searchKey: repos.GitHubSource.GetRepo
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) GetRepo(ctx context.Context, nameWithOwner string) (*types.Repo, error)
+func (s GitHubSource) GetRepo(ctx context.Context, nameWithOwner string) (*types.Repo, error)
 ```
 
-GetRepo returns the Github repository with the given name and owner ("org/repo-name") 
+GetRepo returns the GitHub repository with the given name and owner ("org/repo-name") 
 
-#### <a id="GithubSource.ListRepos" href="#GithubSource.ListRepos">func (s GithubSource) ListRepos(ctx context.Context, results chan SourceResult)</a>
+#### <a id="GitHubSource.ListRepos" href="#GitHubSource.ListRepos">func (s GitHubSource) ListRepos(ctx context.Context, results chan SourceResult)</a>
 
 ```
-searchKey: repos.GithubSource.ListRepos
+searchKey: repos.GitHubSource.ListRepos
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) ListRepos(ctx context.Context, results chan SourceResult)
+func (s GitHubSource) ListRepos(ctx context.Context, results chan SourceResult)
 ```
 
-ListRepos returns all Github repositories accessible to all connections configured in Sourcegraph via the external services configuration. 
+ListRepos returns all GitHub repositories accessible to all connections configured in Sourcegraph via the external services configuration. 
 
-#### <a id="GithubSource.ValidateAuthenticator" href="#GithubSource.ValidateAuthenticator">func (s GithubSource) ValidateAuthenticator(ctx context.Context) error</a>
+#### <a id="GitHubSource.ValidateAuthenticator" href="#GitHubSource.ValidateAuthenticator">func (s GitHubSource) ValidateAuthenticator(ctx context.Context) error</a>
 
 ```
-searchKey: repos.GithubSource.ValidateAuthenticator
+searchKey: repos.GitHubSource.ValidateAuthenticator
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) ValidateAuthenticator(ctx context.Context) error
+func (s GitHubSource) ValidateAuthenticator(ctx context.Context) error
 ```
 
-#### <a id="GithubSource.WithAuthenticator" href="#GithubSource.WithAuthenticator">func (s GithubSource) WithAuthenticator(a auth.Authenticator) (Source, error)</a>
+#### <a id="GitHubSource.WithAuthenticator" href="#GitHubSource.WithAuthenticator">func (s GitHubSource) WithAuthenticator(a auth.Authenticator) (Source, error)</a>
 
 ```
-searchKey: repos.GithubSource.WithAuthenticator
+searchKey: repos.GitHubSource.WithAuthenticator
 tags: [method]
 ```
 
 ```Go
-func (s GithubSource) WithAuthenticator(a auth.Authenticator) (Source, error)
+func (s GitHubSource) WithAuthenticator(a auth.Authenticator) (Source, error)
 ```
 
-#### <a id="GithubSource.excludes" href="#GithubSource.excludes">func (s *GithubSource) excludes(r *github.Repository) bool</a>
+#### <a id="GitHubSource.excludes" href="#GitHubSource.excludes">func (s *GitHubSource) excludes(r *github.Repository) bool</a>
 
 ```
-searchKey: repos.GithubSource.excludes
+searchKey: repos.GitHubSource.excludes
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) excludes(r *github.Repository) bool
+func (s *GitHubSource) excludes(r *github.Repository) bool
 ```
 
-#### <a id="GithubSource.fetchAllRepositoriesInBatches" href="#GithubSource.fetchAllRepositoriesInBatches">func (s *GithubSource) fetchAllRepositoriesInBatches(ctx context.Context, results chan *githubResult) error</a>
+#### <a id="GitHubSource.fetchAllRepositoriesInBatches" href="#GitHubSource.fetchAllRepositoriesInBatches">func (s *GitHubSource) fetchAllRepositoriesInBatches(ctx context.Context, results chan *githubResult) error</a>
 
 ```
-searchKey: repos.GithubSource.fetchAllRepositoriesInBatches
+searchKey: repos.GitHubSource.fetchAllRepositoriesInBatches
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) fetchAllRepositoriesInBatches(ctx context.Context, results chan *githubResult) error
+func (s *GitHubSource) fetchAllRepositoriesInBatches(ctx context.Context, results chan *githubResult) error
 ```
 
 fetchAllRepositoriesInBatches fetches the repositories configured in config.Repos in batches and adds them to the supplied set 
 
-#### <a id="GithubSource.getRepository" href="#GithubSource.getRepository">func (s *GithubSource) getRepository(ctx context.Context, nameWithOwner string) (*github.Repository, error)</a>
+#### <a id="GitHubSource.getRepository" href="#GitHubSource.getRepository">func (s *GitHubSource) getRepository(ctx context.Context, nameWithOwner string) (*github.Repository, error)</a>
 
 ```
-searchKey: repos.GithubSource.getRepository
+searchKey: repos.GitHubSource.getRepository
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) getRepository(ctx context.Context, nameWithOwner string) (*github.Repository, error)
+func (s *GitHubSource) getRepository(ctx context.Context, nameWithOwner string) (*github.Repository, error)
 ```
 
-#### <a id="GithubSource.listAffiliated" href="#GithubSource.listAffiliated">func (s *GithubSource) listAffiliated(ctx context.Context, results chan *githubResult)</a>
+#### <a id="GitHubSource.listAffiliated" href="#GitHubSource.listAffiliated">func (s *GitHubSource) listAffiliated(ctx context.Context, results chan *githubResult)</a>
 
 ```
-searchKey: repos.GithubSource.listAffiliated
+searchKey: repos.GitHubSource.listAffiliated
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) listAffiliated(ctx context.Context, results chan *githubResult)
+func (s *GitHubSource) listAffiliated(ctx context.Context, results chan *githubResult)
 ```
 
 listAffiliated handles the `affiliated` keyword of the `repositoryQuery` config option. It returns the repositories affiliated with the client token by hitting the /user/repos endpoint. 
 
 Affiliation is present if the user: (1) owns the repo, (2) is apart of an org that the repo belongs to, or (3) is a collaborator. 
 
-#### <a id="GithubSource.listAllRepositories" href="#GithubSource.listAllRepositories">func (s *GithubSource) listAllRepositories(ctx context.Context, results chan *githubResult)</a>
+#### <a id="GitHubSource.listAllRepositories" href="#GitHubSource.listAllRepositories">func (s *GitHubSource) listAllRepositories(ctx context.Context, results chan *githubResult)</a>
 
 ```
-searchKey: repos.GithubSource.listAllRepositories
+searchKey: repos.GitHubSource.listAllRepositories
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) listAllRepositories(ctx context.Context, results chan *githubResult)
+func (s *GitHubSource) listAllRepositories(ctx context.Context, results chan *githubResult)
 ```
 
 listAllRepositories returns the repositories from the given `orgs`, `repos`, and `repositoryQuery` config options excluding the ones specified by `exclude`. 
 
-#### <a id="GithubSource.listOrg" href="#GithubSource.listOrg">func (s *GithubSource) listOrg(ctx context.Context, org string, results chan *githubResult)</a>
+#### <a id="GitHubSource.listOrg" href="#GitHubSource.listOrg">func (s *GitHubSource) listOrg(ctx context.Context, org string, results chan *githubResult)</a>
 
 ```
-searchKey: repos.GithubSource.listOrg
+searchKey: repos.GitHubSource.listOrg
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) listOrg(ctx context.Context, org string, results chan *githubResult)
+func (s *GitHubSource) listOrg(ctx context.Context, org string, results chan *githubResult)
 ```
 
 listOrg handles the `org` config option. It returns all the repositories belonging to the given organization by hitting the /orgs/:org/repos endpoint. 
 
 It returns an error if the request fails on the first page. 
 
-#### <a id="GithubSource.listPublic" href="#GithubSource.listPublic">func (s *GithubSource) listPublic(ctx context.Context, results chan *githubResult)</a>
+#### <a id="GitHubSource.listPublic" href="#GitHubSource.listPublic">func (s *GitHubSource) listPublic(ctx context.Context, results chan *githubResult)</a>
 
 ```
-searchKey: repos.GithubSource.listPublic
+searchKey: repos.GitHubSource.listPublic
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) listPublic(ctx context.Context, results chan *githubResult)
+func (s *GitHubSource) listPublic(ctx context.Context, results chan *githubResult)
 ```
 
 listPublic handles the `public` keyword of the `repositoryQuery` config option. It returns the public repositories listed on the /repositories endpoint. 
 
-#### <a id="GithubSource.listRepos" href="#GithubSource.listRepos">func (s *GithubSource) listRepos(ctx context.Context, repos []string, results chan *githubResult)</a>
+#### <a id="GitHubSource.listRepos" href="#GitHubSource.listRepos">func (s *GitHubSource) listRepos(ctx context.Context, repos []string, results chan *githubResult)</a>
 
 ```
-searchKey: repos.GithubSource.listRepos
+searchKey: repos.GitHubSource.listRepos
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) listRepos(ctx context.Context, repos []string, results chan *githubResult)
+func (s *GitHubSource) listRepos(ctx context.Context, repos []string, results chan *githubResult)
 ```
 
 listRepos returns the valid repositories from the given list of repository names. This is done by hitting the /repos/:owner/:name endpoint for each of the given repository names. 
 
-#### <a id="GithubSource.listRepositoryQuery" href="#GithubSource.listRepositoryQuery">func (s *GithubSource) listRepositoryQuery(ctx context.Context, query string, results chan *githubResult)</a>
+#### <a id="GitHubSource.listRepositoryQuery" href="#GitHubSource.listRepositoryQuery">func (s *GitHubSource) listRepositoryQuery(ctx context.Context, query string, results chan *githubResult)</a>
 
 ```
-searchKey: repos.GithubSource.listRepositoryQuery
+searchKey: repos.GitHubSource.listRepositoryQuery
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) listRepositoryQuery(ctx context.Context, query string, results chan *githubResult)
+func (s *GitHubSource) listRepositoryQuery(ctx context.Context, query string, results chan *githubResult)
 ```
 
 listRepositoryQuery handles the `repositoryQuery` config option. The supported keywords to select repositories are: - `public`: public repositories (from endpoint: /repositories) - `affiliated`: repositories affiliated with client token (from endpoint: /user/repos) - `none`: disables `repositoryQuery` Inputs other than these three keywords will be queried using GitHub advanced repository search (endpoint: /search/repositories) 
 
-#### <a id="GithubSource.listSearch" href="#GithubSource.listSearch">func (s *GithubSource) listSearch(ctx context.Context, query string, results chan *githubResult)</a>
+#### <a id="GitHubSource.listSearch" href="#GitHubSource.listSearch">func (s *GitHubSource) listSearch(ctx context.Context, query string, results chan *githubResult)</a>
 
 ```
-searchKey: repos.GithubSource.listSearch
+searchKey: repos.GitHubSource.listSearch
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) listSearch(ctx context.Context, query string, results chan *githubResult)
+func (s *GitHubSource) listSearch(ctx context.Context, query string, results chan *githubResult)
 ```
 
 listSearch handles the `repositoryQuery` config option when a keyword is not present. It returns the repositories resulting from from GitHub's advanced repository search by hitting the /search/repositories endpoint. 
 
-#### <a id="GithubSource.listUser" href="#GithubSource.listUser">func (s *GithubSource) listUser(ctx context.Context, user string, results chan *githubResult) (fail error)</a>
+#### <a id="GitHubSource.listUser" href="#GitHubSource.listUser">func (s *GitHubSource) listUser(ctx context.Context, user string, results chan *githubResult) (fail error)</a>
 
 ```
-searchKey: repos.GithubSource.listUser
+searchKey: repos.GitHubSource.listUser
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) listUser(ctx context.Context, user string, results chan *githubResult) (fail error)
+func (s *GitHubSource) listUser(ctx context.Context, user string, results chan *githubResult) (fail error)
 ```
 
 listUser returns all the repositories belonging to the given user by hitting the /users/:user/repos endpoint. 
 
 It returns an error if the request fails on the first page. 
 
-#### <a id="GithubSource.makeRepo" href="#GithubSource.makeRepo">func (s GithubSource) makeRepo(r *github.Repository) *types.Repo</a>
+#### <a id="GitHubSource.makeRepo" href="#GitHubSource.makeRepo">func (s GitHubSource) makeRepo(r *github.Repository) *types.Repo</a>
 
 ```
-searchKey: repos.GithubSource.makeRepo
+searchKey: repos.GitHubSource.makeRepo
 tags: [method private]
 ```
 
 ```Go
-func (s GithubSource) makeRepo(r *github.Repository) *types.Repo
+func (s GitHubSource) makeRepo(r *github.Repository) *types.Repo
 ```
 
-#### <a id="GithubSource.paginate" href="#GithubSource.paginate">func (s *GithubSource) paginate(ctx context.Context, results chan *githubResult, pager repositoryPager)</a>
+#### <a id="GitHubSource.paginate" href="#GitHubSource.paginate">func (s *GitHubSource) paginate(ctx context.Context, results chan *githubResult, pager repositoryPager)</a>
 
 ```
-searchKey: repos.GithubSource.paginate
+searchKey: repos.GitHubSource.paginate
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) paginate(ctx context.Context, results chan *githubResult, pager repositoryPager)
+func (s *GitHubSource) paginate(ctx context.Context, results chan *githubResult, pager repositoryPager)
 ```
 
 paginate returns all the repositories from the given repositoryPager. It repeatedly calls `pager` with incrementing page count until it returns false for hasNext. 
 
-#### <a id="GithubSource.remoteURL" href="#GithubSource.remoteURL">func (s *GithubSource) remoteURL(repo *github.Repository) string</a>
+#### <a id="GitHubSource.remoteURL" href="#GitHubSource.remoteURL">func (s *GitHubSource) remoteURL(repo *github.Repository) string</a>
 
 ```
-searchKey: repos.GithubSource.remoteURL
+searchKey: repos.GitHubSource.remoteURL
 tags: [method private]
 ```
 
 ```Go
-func (s *GithubSource) remoteURL(repo *github.Repository) string
+func (s *GitHubSource) remoteURL(repo *github.Repository) string
 ```
 
 remoteURL returns the repository's Git remote URL 
@@ -4777,59 +4777,59 @@ tags: [function private test]
 func TestGitLabSource_makeRepo(t *testing.T)
 ```
 
-### <a id="TestGithubSource_GetRepo" href="#TestGithubSource_GetRepo">func TestGithubSource_GetRepo(t *testing.T)</a>
+### <a id="TestGitHubSource_GetRepo" href="#TestGitHubSource_GetRepo">func TestGitHubSource_GetRepo(t *testing.T)</a>
 
 ```
-searchKey: repos.TestGithubSource_GetRepo
+searchKey: repos.TestGitHubSource_GetRepo
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_GetRepo(t *testing.T)
+func TestGitHubSource_GetRepo(t *testing.T)
 ```
 
-### <a id="TestGithubSource_ListRepos" href="#TestGithubSource_ListRepos">func TestGithubSource_ListRepos(t *testing.T)</a>
+### <a id="TestGitHubSource_ListRepos" href="#TestGitHubSource_ListRepos">func TestGitHubSource_ListRepos(t *testing.T)</a>
 
 ```
-searchKey: repos.TestGithubSource_ListRepos
+searchKey: repos.TestGitHubSource_ListRepos
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_ListRepos(t *testing.T)
+func TestGitHubSource_ListRepos(t *testing.T)
 ```
 
-### <a id="TestGithubSource_WithAuthenticator" href="#TestGithubSource_WithAuthenticator">func TestGithubSource_WithAuthenticator(t *testing.T)</a>
+### <a id="TestGitHubSource_WithAuthenticator" href="#TestGitHubSource_WithAuthenticator">func TestGitHubSource_WithAuthenticator(t *testing.T)</a>
 
 ```
-searchKey: repos.TestGithubSource_WithAuthenticator
+searchKey: repos.TestGitHubSource_WithAuthenticator
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_WithAuthenticator(t *testing.T)
+func TestGitHubSource_WithAuthenticator(t *testing.T)
 ```
 
-### <a id="TestGithubSource_excludes_disabledAndLocked" href="#TestGithubSource_excludes_disabledAndLocked">func TestGithubSource_excludes_disabledAndLocked(t *testing.T)</a>
+### <a id="TestGitHubSource_excludes_disabledAndLocked" href="#TestGitHubSource_excludes_disabledAndLocked">func TestGitHubSource_excludes_disabledAndLocked(t *testing.T)</a>
 
 ```
-searchKey: repos.TestGithubSource_excludes_disabledAndLocked
+searchKey: repos.TestGitHubSource_excludes_disabledAndLocked
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_excludes_disabledAndLocked(t *testing.T)
+func TestGitHubSource_excludes_disabledAndLocked(t *testing.T)
 ```
 
-### <a id="TestGithubSource_makeRepo" href="#TestGithubSource_makeRepo">func TestGithubSource_makeRepo(t *testing.T)</a>
+### <a id="TestGitHubSource_makeRepo" href="#TestGitHubSource_makeRepo">func TestGitHubSource_makeRepo(t *testing.T)</a>
 
 ```
-searchKey: repos.TestGithubSource_makeRepo
+searchKey: repos.TestGitHubSource_makeRepo
 tags: [function private test]
 ```
 
 ```Go
-func TestGithubSource_makeRepo(t *testing.T)
+func TestGitHubSource_makeRepo(t *testing.T)
 ```
 
 ### <a id="TestGrantedScopes" href="#TestGrantedScopes">func TestGrantedScopes(t *testing.T)</a>

--- a/examples/sourcegraph-sourcegraph/internal/testutil.md
+++ b/examples/sourcegraph-sourcegraph/internal/testutil.md
@@ -10,7 +10,7 @@
     * [func AssertGolden(t testing.TB, path string, update bool, want interface{})](#AssertGolden)
     * [func CreateZip(files map[string]string) ([]byte, error)](#CreateZip)
     * [func Diff(b1, b2 string) (string, error)](#Diff)
-    * [func FetchTarFromGithub(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error)](#FetchTarFromGithub)
+    * [func FetchTarFromGitHub(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error)](#FetchTarFromGitHub)
     * [func MockZipFile(data []byte) (*store.ZipFile, error)](#MockZipFile)
     * [func NewStore(files map[string]string) (*store.Store, func(), error)](#NewStore)
     * [func TempZipFileOnDisk(data []byte) (string, func(), error)](#TempZipFileOnDisk)
@@ -102,15 +102,15 @@ tags: [function]
 func Diff(b1, b2 string) (string, error)
 ```
 
-### <a id="FetchTarFromGithub" href="#FetchTarFromGithub">func FetchTarFromGithub(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error)</a>
+### <a id="FetchTarFromGitHub" href="#FetchTarFromGitHub">func FetchTarFromGitHub(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error)</a>
 
 ```
-searchKey: testutil.FetchTarFromGithub
+searchKey: testutil.FetchTarFromGitHub
 tags: [function]
 ```
 
 ```Go
-func FetchTarFromGithub(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error)
+func FetchTarFromGitHub(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error)
 ```
 
 ### <a id="MockZipFile" href="#MockZipFile">func MockZipFile(data []byte) (*store.ZipFile, error)</a>

--- a/examples/sourcegraph-sourcegraph/internal/types.md
+++ b/examples/sourcegraph-sourcegraph/internal/types.md
@@ -85,7 +85,7 @@ Package types defines types used by the frontend.
     * [type Repo struct](#Repo)
         * [func MakeAWSCodeCommitRepo(services ...*ExternalService) *Repo](#MakeAWSCodeCommitRepo)
         * [func MakeBitbucketServerRepo(services ...*ExternalService) *Repo](#MakeBitbucketServerRepo)
-        * [func MakeGithubRepo(services ...*ExternalService) *Repo](#MakeGithubRepo)
+        * [func MakeGitHubRepo(services ...*ExternalService) *Repo](#MakeGitHubRepo)
         * [func MakeGitlabRepo(services ...*ExternalService) *Repo](#MakeGitlabRepo)
         * [func MakeGitoliteRepo(services ...*ExternalService) *Repo](#MakeGitoliteRepo)
         * [func MakeOtherRepo(services ...*ExternalService) *Repo](#MakeOtherRepo)
@@ -1457,18 +1457,18 @@ func MakeBitbucketServerRepo(services ...*ExternalService) *Repo
 
 MakeBitbucketServerRepo returns a configured Bitbucket Server repository. 
 
-#### <a id="MakeGithubRepo" href="#MakeGithubRepo">func MakeGithubRepo(services ...*ExternalService) *Repo</a>
+#### <a id="MakeGitHubRepo" href="#MakeGitHubRepo">func MakeGitHubRepo(services ...*ExternalService) *Repo</a>
 
 ```
-searchKey: types.MakeGithubRepo
+searchKey: types.MakeGitHubRepo
 tags: [function]
 ```
 
 ```Go
-func MakeGithubRepo(services ...*ExternalService) *Repo
+func MakeGitHubRepo(services ...*ExternalService) *Repo
 ```
 
-MakeGithubRepo returns a configured Github repository. 
+MakeGitHubRepo returns a configured GitHub repository. 
 
 #### <a id="MakeGitlabRepo" href="#MakeGitlabRepo">func MakeGitlabRepo(services ...*ExternalService) *Repo</a>
 

--- a/examples/sourcegraph-sourcegraph/schema.md
+++ b/examples/sourcegraph-sourcegraph/schema.md
@@ -514,7 +514,7 @@ type AuthProviders struct {
 	Saml          *SAMLAuthProvider
 	Openidconnect *OpenIDConnectAuthProvider
 	HttpHeader    *HTTPHeaderAuthProvider
-	Github        *GitHubAuthProvider
+	GitHub        *GitHubAuthProvider
 	Gitlab        *GitLabAuthProvider
 }
 ```
@@ -2814,10 +2814,10 @@ type SiteConfiguration struct {
 	GitMaxConcurrentClones int `json:"gitMaxConcurrentClones,omitempty"`
 	// GitUpdateInterval description: JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.
 	GitUpdateInterval []*UpdateIntervalRule `json:"gitUpdateInterval,omitempty"`
-	// GithubClientID description: Client ID for GitHub. (DEPRECATED)
-	GithubClientID string `json:"githubClientID,omitempty"`
-	// GithubClientSecret description: Client secret for GitHub. (DEPRECATED)
-	GithubClientSecret string `json:"githubClientSecret,omitempty"`
+	// GitHubClientID description: Client ID for GitHub. (DEPRECATED)
+	GitHubClientID string `json:"githubClientID,omitempty"`
+	// GitHubClientSecret description: Client secret for GitHub. (DEPRECATED)
+	GitHubClientSecret string `json:"githubClientSecret,omitempty"`
 	// HtmlBodyBottom description: HTML to inject at the bottom of the `<body>` element on each page, for analytics scripts
 	HtmlBodyBottom string `json:"htmlBodyBottom,omitempty"`
 	// HtmlBodyTop description: HTML to inject at the top of the `<body>` element on each page, for analytics scripts


### PR DESCRIPTION


[_Created by Sourcegraph batch change `sqs/github-case`._](https://sourcegraph.sourcegraph.com/users/sqs/batch-changes/github-case)